### PR TITLE
Convert non-serializable objects to string

### DIFF
--- a/cli/gardener_ci/yaml2json.py
+++ b/cli/gardener_ci/yaml2json.py
@@ -10,7 +10,7 @@ def main():
     fh = open(sys.argv[1])
   else:
     fh = sys.stdin
-  json.dump(yaml.load(fh, Loader=yaml.SafeLoader), sys.stdout)
+  json.dump(yaml.load(fh, Loader=yaml.SafeLoader), sys.stdout, default=str)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What this PR does / why we need it**:
The yaml2json function throws an error if the yaml file contains a non-serializable object, e.g. datetime:
```
Traceback (most recent call last):
  File "/usr/bin/yaml2json", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.8/site-packages/gardener_ci/yaml2json.py", line 13, in main
    json.dump(yaml.load(fh, Loader=yaml.SafeLoader), sys.stdout)
  File "/usr/lib/python3.8/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/usr/lib/python3.8/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.8/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  [Previous line repeated 1 more time]
  File "/usr/lib/python3.8/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

Using the `default` parameter converts these objects to strings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement developer
The `yaml2json` function now converts non-serializable objects to string
```
